### PR TITLE
Fix "Parameter count mismatch." error

### DIFF
--- a/SharpCradle/Program.cs
+++ b/SharpCradle/Program.cs
@@ -94,8 +94,8 @@ namespace SharpCradle
                 MethodInfo method = a.EntryPoint;
                 if (method != null)
                 {
-                    object o = a.CreateInstance(method.Name);                    
-                    method.Invoke(o, null);
+                    object[] parameters = method.GetParameters().Length == 0 ? null : new object[] { new string[0] };
+                    method.Invoke(null, parameters);
                 }
             }//End try/catch            
         }//End loadAssembly


### PR DESCRIPTION
```
Unhandled Exception: System.Reflection.TargetParameterCountException: Parameter count mismatch.
   at System.Reflection.RuntimeMethodInfo.InvokeArgumentsCheck(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at SC.Program.lA(Byte[] bin, Object[] commands)
   at SC.Program.Main(String[] args)
```

Solution found here https://stackoverflow.com/questions/48379365/parameter-count-mismatch-on-running-exe-from-memory